### PR TITLE
fix: 나눔 목록 조회 무한 스크롤 되도록 수정, 호출시 query parameter 추가

### DIFF
--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -1,4 +1,8 @@
-import type { FriendshipSortType } from '@/types/friendship';
+import type {
+  FriendshipSortType,
+  ShareSortType,
+  ShareStatusType,
+} from '@/types/friendship';
 
 export const queryKeys = {
   MY_FRIDGE_LIST: () => ['my_fridge_list'],
@@ -8,7 +12,11 @@ export const queryKeys = {
   INGREDIENT_ID: (id: number) => ['ingredient', id],
   INGREDIENTS: () => ['my-ingredient'],
   KAKAO: () => ['kakao'],
-  SHARES: () => ['shares'],
+  SHARES: (sort: ShareSortType, status: ShareStatusType) => [
+    'shares',
+    sort,
+    status,
+  ],
   ME: () => ['my-info'],
   FRIENDSHIPS: (sort: FriendshipSortType) => ['friendship', sort],
   DELETE_FRIENDSHIP: () => ['deleteFriendship'],

--- a/src/hooks/queries/share/useGetShares.ts
+++ b/src/hooks/queries/share/useGetShares.ts
@@ -1,7 +1,18 @@
+import { type ShareStatusType, type ShareSortType } from '@/types/friendship';
 import { queryKeys } from '../queryKeys';
-import { useBaseQuery } from '../useBaseQuery';
+import { useBaseInfiniteQuery } from '../useBaseInfiniteQuery';
 
-const useGetShares = () =>
-  useBaseQuery<ShareData[]>(queryKeys.SHARES(), '/shares', true);
+const useGetShares = ({
+  sort,
+  status,
+}: {
+  sort: ShareSortType;
+  status: ShareStatusType;
+}) =>
+  useBaseInfiniteQuery<ShareData[]>({
+    queryKey: queryKeys.SHARES(sort, status),
+    url: '/shares',
+    params: { sort, status },
+  });
 
 export default useGetShares;

--- a/src/types/friendship/index.d.ts
+++ b/src/types/friendship/index.d.ts
@@ -8,3 +8,7 @@ export interface FriendshipData {
 }
 
 export type FriendshipSortType = 'nickname' | 'createdAt';
+
+export type ShareSortType = 'dueDate' | 'registeredDate';
+
+export type ShareStatusType = 'SHARE_START' | 'SHARE_IN_PROGRESS' | 'SHARE_END';


### PR DESCRIPTION
## 요구사항
이슈번호: [MARA-80](https://alsehf0316.atlassian.net/browse/MARA-80)

## 작업내용
- 나눔 목록 조회 API 무한스크롤 구현 
- status, sort type query parameter로 추가 

## 테스트 결과 또는 방법
- 나눔 목록 전체 데이터 조회 가능한지 조회
- 탭, 정렬기준 바꿔가면서 나눔 목록 데이터 조회


[MARA-80]: https://alsehf0316.atlassian.net/browse/MARA-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ